### PR TITLE
feat: Extend supported backends - Redis, PgSQL

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,8 @@
+experimental = ["setup-scripts"]
+
+[script.services]
+command = 'bash -c "docker compose up -d --wait ; sleep 1"'
+
+[[profile.default.scripts]]
+filter = 'test(redis::) | test(pgsql::)'
+setup = ['services']

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -21,9 +21,27 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: valkey/valkey:7.2.7-alpine
+        ports:
+          - 16379:6379
+      pgsql:
+        image: postgres:16.4
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_USER: test
+          POSTGRES_DB: test
+        ports:
+          - 15432:5432
     steps:
       - uses: actions/checkout@v2
       - name: Tests
         run: cargo test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Build
         run: cargo build --release --verbose

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ async fn main() {
         .await
         .expect("Membership database connection failure");
     let members_storage = SqlMembersStorage::new(pool);
-    members_storage.migrate().await;
 
     let membership_provider_config = PeerToPeerClusterConfig::default();
     let membership_provider =
@@ -82,7 +81,6 @@ async fn main() {
         .await
         .expect("Object placement database connection failure");
     let object_placement_provider = SqlObjectPlacementProvider::new(pool);
-    object_placement_provider.migrate().await;
 
     // Create the server object
     let mut server = Server::new(
@@ -91,6 +89,7 @@ async fn main() {
         membership_provider,
         object_placement_provider,
     );
+    server.prepare().await;
 
     // Run the server
     // server.run().await;
@@ -114,7 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .connect("sqlite::memory:")
         .await?;
     let members_storage = SqlMembersStorage::new(pool);
-    # members_storage.migrate().await;
+    # members_storage.prepare().await;
 
     // Create the client
     let mut client = ClientBuilder::new()
@@ -140,6 +139,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 There are a few things that must be done before v0.1.0:
 
+### Version 0.1.0
+
 - [x] Naive server/client protocol
 - [x] Basic cluster support
 - [x] Basic placement support
@@ -156,14 +157,23 @@ There are a few things that must be done before v0.1.0:
   - [x] Background blocking task on a service (_see_ [black-jack](./examples/black-jack))
   - [x] Pub/sub (_see_ [black-jack](./examples/black-jack))
 - [x] Re-organize workspace
+- [x] Support ephemeral port
+- [x] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
+- [?] Support 'typed' message/response on client
+- [ ] Error and panic handling on life cycle hooks (probably kill the object)
+- [ ] Handle panics on messages handling
+- [x] Sqlite support for sql backends
+- [x] PostgreSQL support for sql backends
+
+### Version 0.2.0
+
+- [ ] Client doesn't need to have a access to the cluster backend if we implement an HTTP API
 - [ ] Allow `ServiceObject` trait without state persistence
 - [ ] Create server from config
 - [ ] Bypass clustering for self messages
 - [ ] Bypass networking for local messages
 - [ ] Move all the client to user tower
 - [ ] Remove the need to pass the StateSaver to `ObjectStateManager::save_state`
-- [ ] Error and panic handling on life cycle hooks (probably kill the object)
-- [ ] Handle panics on messages handling
 - [ ] Include registry configuration in Server builder
 - [ ] Create a getting started tutorial
   - [ ] Cargo init
@@ -176,14 +186,14 @@ There are a few things that must be done before v0.1.0:
   - [ ] Life cycle
   - [ ] Life cycle depends on app_data(StateLoader + StateSaver)
   - [ ] Cargo test?
-- [ ] Make all sql statements compatible with sqlite, mysql and pgsql
+- [ ] MySQL support for sql backends
 - [ ] Add more extensive tests to client/server integration
 - [ ] Increase public API test coverage
 - [ ] Client/server keep alive
 - [ ] Reduce static lifetimes
 - [ ] 100% documentation of public API
 - [ ] Placement strategies (nodes work with different sets of trait objects)
-- [ ] Dockerized examples
+- [~] Dockerized examples
 - [ ] Add pgsql jsonb support
 - [ ] Add all SQL storage behind a feature flag (sqlite, mysql, pgsql, etc)
 - [ ] Supervision
@@ -192,9 +202,6 @@ There are a few things that must be done before v0.1.0:
 - [ ] Object TTL
 - [ ] Matrix test with different backends
 - [ ] Replace prints with logging
-- [?] Support 'typed' message/response on client
-- [x] Support ephemeral port
-- [ ] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
 - [ ] Code of conduct
 - [ ] Metrics and Tracing
 - [ ] Deny allocations based on system resources

--- a/README.md
+++ b/README.md
@@ -160,11 +160,15 @@ There are a few things that must be done before v0.1.0:
 - [x] Support ephemeral port
 - [x] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
 - [ ] Support 'typed' message/response on client (TODO define what this means)
+- [ ] `ServiceObject::send` shouldn't need a type for the member storage
 - [x] Handle panics on messages handling
 - [x] Error and panic handling on life cycle hooks (probably kill the object)
 - [x] Create a test or example to show re-allocation when servers dies
 - [x] Sqlite support for sql backends
 - [x] PostgreSQL support for sql backends
+- [!] Redis support for members storage
+- [!] Redis support for state backend (loader and saver)
+- [!] Redis support for object placement
 
 ### Version 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ There are a few things that must be done before v0.1.0:
 - [x] Re-organize workspace
 - [x] Support ephemeral port
 - [x] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
-- [?] Support 'typed' message/response on client
-- [ ] Error and panic handling on life cycle hooks (probably kill the object)
-- [ ] Handle panics on messages handling
+- [ ] Support 'typed' message/response on client (TODO define what this means)
+- [x] Handle panics on messages handling
+- [x] Error and panic handling on life cycle hooks (probably kill the object)
+- [ ] Create a test or example to show re-allocation when servers dies
 - [x] Sqlite support for sql backends
 - [x] PostgreSQL support for sql backends
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ There are a few things that must be done before v0.1.0:
 - [ ] Remove magic numbers
 - [ ] Object TTL
 - [ ] Matrix test with different backends
-- [ ] Replace prints with logging
+- [x] Replace prints with logging
 - [ ] Code of conduct
 - [ ] Metrics and Tracing
 - [ ] Deny allocations based on system resources

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ There are a few things that must be done before v0.1.0:
 - [ ] Support 'typed' message/response on client (TODO define what this means)
 - [x] Handle panics on messages handling
 - [x] Error and panic handling on life cycle hooks (probably kill the object)
-- [ ] Create a test or example to show re-allocation when servers dies
+- [x] Create a test or example to show re-allocation when servers dies
 - [x] Sqlite support for sql backends
 - [x] PostgreSQL support for sql backends
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -28,9 +28,9 @@ There are a few things that must be done before v0.1.0:
 - [x] Re-organize workspace
 - [x] Support ephemeral port
 - [x] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
-- [?] Support 'typed' message/response on client
-- [ ] Error and panic handling on life cycle hooks (probably kill the object)
-- [ ] Handle panics on messages handling
+- [ ] Support 'typed' message/response on client (TODO define what this means)
+- [x] Handle panics on messages handling
+- [x] Error and panic handling on life cycle hooks (probably kill the object)
 - [ ] Create a test or example to show re-allocation when servers dies
 - [x] Sqlite support for sql backends
 - [x] PostgreSQL support for sql backends

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -8,6 +8,8 @@
 
 There are a few things that must be done before v0.1.0:
 
+### Version 0.1.0
+
 - [x] Naive server/client protocol
 - [x] Basic cluster support
 - [x] Basic placement support
@@ -24,14 +26,24 @@ There are a few things that must be done before v0.1.0:
   - [x] Background blocking task on a service (_see_ [black-jack](./examples/black-jack))
   - [x] Pub/sub (_see_ [black-jack](./examples/black-jack))
 - [x] Re-organize workspace
+- [x] Support ephemeral port
+- [x] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
+- [?] Support 'typed' message/response on client
+- [ ] Error and panic handling on life cycle hooks (probably kill the object)
+- [ ] Handle panics on messages handling
+- [ ] Create a test or example to show re-allocation when servers dies
+- [x] Sqlite support for sql backends
+- [x] PostgreSQL support for sql backends
+
+### Version 0.2.0
+
+- [ ] Client doesn't need to have a access to the cluster backend if we implement an HTTP API
 - [ ] Allow `ServiceObject` trait without state persistence
 - [ ] Create server from config
 - [ ] Bypass clustering for self messages
 - [ ] Bypass networking for local messages
 - [ ] Move all the client to user tower
 - [ ] Remove the need to pass the StateSaver to `ObjectStateManager::save_state`
-- [ ] Error and panic handling on life cycle hooks (probably kill the object)
-- [ ] Handle panics on messages handling
 - [ ] Include registry configuration in Server builder
 - [ ] Create a getting started tutorial
   - [ ] Cargo init
@@ -44,14 +56,14 @@ There are a few things that must be done before v0.1.0:
   - [ ] Life cycle
   - [ ] Life cycle depends on app_data(StateLoader + StateSaver)
   - [ ] Cargo test?
-- [ ] Make all sql statements compatible with sqlite, mysql and pgsql
+- [ ] MySQL support for sql backends
 - [ ] Add more extensive tests to client/server integration
 - [ ] Increase public API test coverage
 - [ ] Client/server keep alive
 - [ ] Reduce static lifetimes
 - [ ] 100% documentation of public API
 - [ ] Placement strategies (nodes work with different sets of trait objects)
-- [ ] Dockerized examples
+- [~] Dockerized examples
 - [ ] Add pgsql jsonb support
 - [ ] Add all SQL storage behind a feature flag (sqlite, mysql, pgsql, etc)
 - [ ] Supervision
@@ -60,9 +72,6 @@ There are a few things that must be done before v0.1.0:
 - [ ] Object TTL
 - [ ] Matrix test with different backends
 - [ ] Replace prints with logging
-- [?] Support 'typed' message/response on client
-- [x] Support ephemeral port
-- [x] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
 - [ ] Code of conduct
 - [ ] Metrics and Tracing
 - [ ] Deny allocations based on system resources

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -31,7 +31,7 @@ There are a few things that must be done before v0.1.0:
 - [ ] Support 'typed' message/response on client (TODO define what this means)
 - [x] Handle panics on messages handling
 - [x] Error and panic handling on life cycle hooks (probably kill the object)
-- [ ] Create a test or example to show re-allocation when servers dies
+- [x] Create a test or example to show re-allocation when servers dies
 - [x] Sqlite support for sql backends
 - [x] PostgreSQL support for sql backends
 

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -71,7 +71,7 @@ There are a few things that must be done before v0.1.0:
 - [ ] Remove magic numbers
 - [ ] Object TTL
 - [ ] Matrix test with different backends
-- [ ] Replace prints with logging
+- [x] Replace prints with logging
 - [ ] Code of conduct
 - [ ] Metrics and Tracing
 - [ ] Deny allocations based on system resources

--- a/README.tpl.md
+++ b/README.tpl.md
@@ -29,11 +29,15 @@ There are a few things that must be done before v0.1.0:
 - [x] Support ephemeral port
 - [x] Remove the need for an `Option<T>` value for `managed_state` attributes (as long as it has a 'Default')
 - [ ] Support 'typed' message/response on client (TODO define what this means)
+- [ ] `ServiceObject::send` shouldn't need a type for the member storage
 - [x] Handle panics on messages handling
 - [x] Error and panic handling on life cycle hooks (probably kill the object)
 - [x] Create a test or example to show re-allocation when servers dies
 - [x] Sqlite support for sql backends
 - [x] PostgreSQL support for sql backends
+- [!] Redis support for members storage
+- [!] Redis support for state backend (loader and saver)
+- [!] Redis support for object placement
 
 ### Version 0.2.0
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  redis:
+    image: valkey/valkey:7.2.7-alpine
+    ports:
+      - 16379:6379
+  pgsql:
+    image: postgres:16.4
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: test
+      POSTGRES_USER: test
+      POSTGRES_DB: test
+    ports:
+      - 15432:5432

--- a/examples/black-jack/README.md
+++ b/examples/black-jack/README.md
@@ -24,3 +24,5 @@ To run the client:
 ```sh
 cargo run --bin client PLAYER_ID
 ```
+
+There are two handy scripts to run the server using either CockroachDB or Sqlite3: `run-server-cockroach` and `run-server-sqlite`

--- a/examples/black-jack/compose-cockroach.yaml
+++ b/examples/black-jack/compose-cockroach.yaml
@@ -1,0 +1,8 @@
+services:
+  database:
+    image: cockroachdb/cockroach:v24.2.2
+    platform: linux/amd64
+    command: start-single-node --insecure
+    ports:
+      - 8000:8080
+      - 26257:26257

--- a/examples/black-jack/run-server-cockroach
+++ b/examples/black-jack/run-server-cockroach
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+docker compose -f compose-cockroach.yaml up -d --wait
+sleep 10
+echo Run the client with the command:
+echo cargo run --bin client -- -c postgres://root@localhost:26257/defaultdb CLIENT_001
+cargo run --bin server -- -c postgres://root@localhost:26257/defaultdb \
+                          -o postgres://root@localhost:26257/defaultdb \
+                          -s postgres://root@localhost:26257/defaultdb  \
+                          9999

--- a/examples/black-jack/run-server-sqlite
+++ b/examples/black-jack/run-server-sqlite
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo Run the client with the command:
+echo cargo run --bin client -- CLIENT_001
+cargo run --bin server -- 9999

--- a/examples/black-jack/src/bin/client.rs
+++ b/examples/black-jack/src/bin/client.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
 
     sleep(Duration::from_secs(1)).await;
 
-    members_storage.migrate().await;
+    members_storage.prepare().await;
     let servers = members_storage.active_members().await;
     println!("server: {:?}", servers);
 

--- a/examples/metric-aggregator/src/bin/client.rs
+++ b/examples/metric-aggregator/src/bin/client.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     sleep(Duration::from_secs(1)).await;
 
-    members_storage.migrate().await;
+    members_storage.prepare().await;
     let servers = members_storage.active_members().await;
     println!("server: {:?}", servers);
 

--- a/examples/metric-aggregator/src/bin/dropall.rs
+++ b/examples/metric-aggregator/src/bin/dropall.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     sleep(Duration::from_secs(1)).await;
 
-    members_storage.migrate().await;
+    members_storage.prepare().await;
     let servers = members_storage.active_members().await;
     println!("server: {:?}", servers);
 

--- a/examples/metric-aggregator/src/bin/loadall.rs
+++ b/examples/metric-aggregator/src/bin/loadall.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     sleep(Duration::from_secs(1)).await;
 
-    members_storage.migrate().await;
+    members_storage.prepare().await;
     let servers = members_storage.active_members().await;
     println!("server: {:?}", servers);
 

--- a/examples/ping-pong/src/bin/client.rs
+++ b/examples/ping-pong/src/bin/client.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     sleep(Duration::from_secs(1)).await;
 
-    members_storage.migrate().await;
+    members_storage.prepare().await;
     let servers = members_storage.active_members().await;
     println!("server: {:?}", servers);
 

--- a/examples/presence/src/bin/client.rs
+++ b/examples/presence/src/bin/client.rs
@@ -15,7 +15,7 @@ async fn main() {
     let members_storage = SqlMembersStorage::new(pool);
     sleep(Duration::from_secs(1)).await;
 
-    members_storage.migrate().await;
+    members_storage.prepare().await;
     let servers = members_storage.active_members().await;
     println!("server: {:?}", servers);
 

--- a/examples/presence/src/bin/server.rs
+++ b/examples/presence/src/bin/server.rs
@@ -41,7 +41,6 @@ pub async fn build_server(
         .await
         .unwrap();
     let members_storage = SqlMembersStorage::new(pool);
-    members_storage.migrate().await;
 
     let membership_provider_config = PeerToPeerClusterConfig::default();
     let membership_provider =
@@ -54,7 +53,6 @@ pub async fn build_server(
         .unwrap();
 
     let object_placement_provider = SqlObjectPlacementProvider::new(pool);
-    object_placement_provider.migrate().await;
 
     // Create the server object
     let mut server = Server::new(
@@ -63,6 +61,7 @@ pub async fn build_server(
         membership_provider,
         object_placement_provider,
     );
+    server.prepare().await;
     // LifecycleMessage will try to load object from state
     server.app_data(LocalState::default());
     server

--- a/rio-rs/Cargo.toml
+++ b/rio-rs/Cargo.toml
@@ -49,9 +49,10 @@ sqlx = { version = "0.6", features = [
 async-stream = "0.3.5"
 derive_builder = "0.20.0"
 sync_wrapper = "1.0.1"
-papaya = "0.1.4"
 env_logger = "0.11.5"
 log = { version = "0.4.22", features = ["kv"] }
+redis = "0.27.5"
+bb8-redis = "0.17.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/rio-rs/Cargo.toml
+++ b/rio-rs/Cargo.toml
@@ -49,6 +49,9 @@ sqlx = { version = "0.6", features = [
 async-stream = "0.3.5"
 derive_builder = "0.20.0"
 sync_wrapper = "1.0.1"
+papaya = "0.1.4"
+env_logger = "0.11.5"
+log = { version = "0.4.22", features = ["kv"] }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/rio-rs/Cargo.toml
+++ b/rio-rs/Cargo.toml
@@ -48,6 +48,7 @@ sqlx = { version = "0.6", features = [
 ] }
 async-stream = "0.3.5"
 derive_builder = "0.20.0"
+sync_wrapper = "1.0.1"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/rio-rs/src/client/mod.rs
+++ b/rio-rs/src/client/mod.rs
@@ -295,6 +295,11 @@ where
 
     /// Send a request to the cluster transparently (the caller doesn't need to know where the
     /// object is placed)
+    ///
+    ///
+    /// TODO -  When the cached or selected server are not available, it needs to refresh all the
+    ///         cache and try a different server, this process needs to repeat until it finds a new
+    ///         available server
     pub async fn send<T>(
         &mut self,
         handler_type: impl AsRef<str>,
@@ -405,9 +410,10 @@ where
         }
     }
 
-    /// <div class="warning">
-    /// *TODO* remove this?
-    /// </div>
+    /// Connects to a the first server of the MembersStorage
+    ///
+    /// This is used mostly by the PeerToPeerClusterProvider to check whether
+    /// a set of servers is reacheable and alive
     pub async fn ping(&mut self) -> Result<(), ClientError> {
         let servers = self
             .members_storage

--- a/rio-rs/src/cluster/membership_protocol/peer_to_peer.rs
+++ b/rio-rs/src/cluster/membership_protocol/peer_to_peer.rs
@@ -96,7 +96,8 @@ where
         local_storage.push(member.clone()).await?;
         let mut client = Client::new(local_storage);
 
-        if (client.ping().await).is_err() {
+        let ping = client.ping().await;
+        if ping.is_err() {
             self.members_storage()
                 .notify_failure(member.ip(), member.port())
                 .await?;
@@ -185,7 +186,7 @@ where
             futures::future::join_all(future_member_tests).await;
 
             // Wait for the remaining of 'config.interval_secs'
-            let elapsed = t0.elapsed().expect("fail to get elapsed time");
+            let elapsed = t0.elapsed().expect("Fail to get elapsed time");
             let remaning_sleep_period = sleep_period.saturating_sub(elapsed);
             if remaning_sleep_period > Duration::ZERO {
                 tokio::time::sleep(remaning_sleep_period).await;

--- a/rio-rs/src/cluster/storage/migrations/0001-postgres-init.sql
+++ b/rio-rs/src/cluster/storage/migrations/0001-postgres-init.sql
@@ -1,0 +1,22 @@
+--  Membership
+CREATE TABLE IF NOT EXISTS cluster_provider_members
+   (
+       ip              TEXT                NOT NULL,
+       port            TEXT                NOT NULL,
+       last_seen       TIMESTAMPTZ         NOT NULL,
+       active          BOOLEAN             NOT NULL DEFAULT FALSE,
+       PRIMARY KEY (ip, port)
+   );
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_members_last_seen on cluster_provider_members(last_seen);
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_members_active on cluster_provider_members(active);
+
+-- Clustering check failures
+CREATE TABLE IF NOT EXISTS cluster_provider_member_failures
+   (
+       id              SERIAL PRIMARY KEY,
+       ip              TEXT                              NOT NULL,
+       port            TEXT                              NOT NULL,
+       time            TIMESTAMPTZ                       NOT NULL default CURRENT_TIMESTAMP
+   );
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_member_failures_time ON cluster_provider_member_failures(time);
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_member_failures_ip_port ON cluster_provider_member_failures(ip, port);

--- a/rio-rs/src/cluster/storage/migrations/0001-sqlite-init.sql
+++ b/rio-rs/src/cluster/storage/migrations/0001-sqlite-init.sql
@@ -1,0 +1,22 @@
+--  Membership
+CREATE TABLE IF NOT EXISTS cluster_provider_members
+   (
+       ip              TEXT                NOT NULL,
+       port            TEXT                NOT NULL,
+       last_seen       TIMESTAMPTZ         NOT NULL,
+       active          BOOLEAN             NOT NULL DEFAULT FALSE,
+       PRIMARY KEY (ip, port)
+   );
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_members_last_seen on cluster_provider_members(last_seen);
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_members_active on cluster_provider_members(active);
+
+-- Clustering check failures
+CREATE TABLE IF NOT EXISTS cluster_provider_member_failures
+   (
+       id              SERIAL PRIMARY KEY,
+       ip              TEXT                              NOT NULL,
+       port            TEXT                              NOT NULL,
+       time            TIMESTAMPTZ                       NOT NULL default CURRENT_TIMESTAMP
+   );
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_member_failures_time ON cluster_provider_member_failures(time);
+CREATE INDEX IF NOT EXISTS idx_cluster_provider_member_failures_ip_port ON cluster_provider_member_failures(ip, port);

--- a/rio-rs/src/cluster/storage/mod.rs
+++ b/rio-rs/src/cluster/storage/mod.rs
@@ -55,6 +55,8 @@ pub type MembershipUnitResult = Result<(), MembershipError>;
 /// status.
 #[async_trait]
 pub trait MembersStorage: Send + Sync + Clone {
+    async fn prepare(&self) {}
+
     /// Saves a new member to the storage
     async fn push(&self, member: Member) -> MembershipUnitResult;
 

--- a/rio-rs/src/cluster/storage/mod.rs
+++ b/rio-rs/src/cluster/storage/mod.rs
@@ -8,6 +8,7 @@ use chrono::{DateTime, TimeZone, Utc};
 use crate::errors::MembershipError;
 
 pub mod local;
+pub mod redis;
 pub mod sql;
 
 /// Represents a running [Server](crate::server::Server).

--- a/rio-rs/src/cluster/storage/redis.rs
+++ b/rio-rs/src/cluster/storage/redis.rs
@@ -1,0 +1,118 @@
+use async_trait::async_trait;
+use bb8_redis::{bb8::Pool, RedisConnectionManager};
+use chrono::{DateTime, Utc};
+use redis::AsyncCommands;
+
+use super::{Member, MembersStorage, MembershipResult, MembershipUnitResult};
+
+#[derive(Clone)]
+pub struct RedisMembersStorage {
+    pool: Pool<RedisConnectionManager>,
+    key_prefix: String,
+}
+
+impl RedisMembersStorage {
+    pub async fn from_connect_string(connection_string: &str, key_prefix: Option<String>) -> Self {
+        let conn_manager = RedisConnectionManager::new(connection_string).expect("TODO");
+        let pool = Pool::builder().build(conn_manager).await.expect("TODO");
+        let key_prefix = key_prefix.unwrap_or_default();
+        RedisMembersStorage { pool, key_prefix }
+    }
+}
+
+fn member_to_string(member: &Member) -> String {
+    let member = format!(
+        "{};{};{};{}",
+        member.ip,
+        member.port,
+        member.active(),
+        member.last_seen().to_rfc3339()
+    );
+    member
+}
+
+fn parse_member(member: &str) -> Member {
+    let mut split_member = member.split(";");
+    let ip = split_member.next().expect("TODO").to_string();
+    let port = split_member.next().expect("TODO").to_string();
+    let mut parsed_member = Member::new(ip, port);
+    parsed_member.active = split_member
+        .next()
+        .expect("TODO next")
+        .parse()
+        .expect("TODO parse");
+    let last_seen = split_member.next().expect("TODO");
+    parsed_member.last_seen = DateTime::parse_from_rfc3339(&last_seen)
+        .expect("TODO")
+        .to_utc();
+    parsed_member
+}
+
+#[async_trait]
+impl MembersStorage for RedisMembersStorage {
+    async fn push(&self, member: Member) -> MembershipUnitResult {
+        let mut client = self.pool.get().await.expect("TODO");
+        let member_id = format!("{}:{}", member.ip, member.port,);
+        let member_val = member_to_string(&member);
+
+        let key = format!("{}members", self.key_prefix);
+        let _: () = client
+            .hset(&key, member_id, member_val)
+            .await
+            .expect("TODO");
+        Ok(())
+    }
+
+    async fn remove(&self, ip: &str, port: &str) -> MembershipUnitResult {
+        let mut client = self.pool.get().await.expect("TODO");
+        let member_id = format!("{};{}", ip, port);
+        let key = format!("{}members", self.key_prefix);
+        let _: () = client.hdel(&key, member_id).await.expect("TODO");
+        Ok(())
+    }
+
+    async fn set_is_active(&self, ip: &str, port: &str, is_active: bool) -> MembershipUnitResult {
+        let mut client = self.pool.get().await.expect("TODO");
+        let member_id = format!("{};{}", ip, port);
+        let key = format!("{}members", self.key_prefix);
+        let raw_member: Option<String> = client.hget(&key, &member_id).await.expect("TODO");
+        let mut member = raw_member
+            .map(|x| parse_member(&x))
+            .unwrap_or_else(|| Member::new(ip.to_string(), port.to_string()));
+        member.active = is_active;
+        self.push(member).await?;
+        Ok(())
+    }
+
+    async fn members(&self) -> MembershipResult<Vec<Member>> {
+        let mut client = self.pool.get().await.expect("TODO");
+        let key = format!("{}members", self.key_prefix);
+        let members_raw: Vec<(String, String)> = client.hgetall(&key).await.expect("TODO");
+        let members: Vec<Member> = members_raw.iter().map(|(_, x)| parse_member(x)).collect();
+        Ok(members)
+    }
+
+    async fn notify_failure(&self, ip: &str, port: &str) -> MembershipUnitResult {
+        let mut client = self.pool.get().await.expect("TODO");
+        let k = format!("{}member_failures;{};{}", self.key_prefix, ip, port);
+        let now = chrono::Local::now().to_utc();
+        let ts = now.timestamp();
+        let _: () = client.rpush(&k, ts).await.expect("TODO");
+        let _: () = client.ltrim(&k, 0, 99).await.expect("TODO");
+        Ok(())
+    }
+
+    async fn member_failures(&self, ip: &str, port: &str) -> MembershipResult<Vec<DateTime<Utc>>> {
+        let mut client = self.pool.get().await.expect("TODO");
+        let k = format!("{}member_failures;{};{}", self.key_prefix, ip, port);
+        let values: Vec<String> = client.lrange(&k, 0, -1).await.expect("TODO");
+        let parsed_values = values
+            .iter()
+            .map(|x| {
+                let ts: i64 = x.parse().expect("TODO");
+                DateTime::from_timestamp(ts, 0).expect("TODO").to_utc()
+            })
+            .collect();
+        Ok(parsed_values)
+    }
+}

--- a/rio-rs/src/cluster/storage/sql.rs
+++ b/rio-rs/src/cluster/storage/sql.rs
@@ -118,7 +118,7 @@ impl MembersStorage for SqlMembersStorage {
         sqlx::query("UPDATE cluster_provider_members SET active = $3 WHERE ip = $1 and port = $2")
             .bind(ip)
             .bind(port)
-            .bind(is_active as i32)
+            .bind(is_active)
             .execute(&self.pool)
             .err_into()
             .await

--- a/rio-rs/src/errors.rs
+++ b/rio-rs/src/errors.rs
@@ -110,11 +110,17 @@ impl From<MembershipError> for ClusterProviderServeError {
 }
 
 /// Error type for service object state management
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum LoadStateError {
     #[error("object not found")]
     ObjectNotFound,
 
     #[error("unknown error")]
     Unknown,
+
+    #[error("deserialization error")]
+    DeserializationError,
+
+    #[error("serialization error")]
+    SerializationError,
 }

--- a/rio-rs/src/lib.rs
+++ b/rio-rs/src/lib.rs
@@ -94,7 +94,6 @@
 //!         .await
 //!         .expect("Membership database connection failure");
 //!     let members_storage = SqlMembersStorage::new(pool);
-//!     members_storage.migrate().await;
 //!
 //!     let membership_provider_config = PeerToPeerClusterConfig::default();
 //!     let membership_provider =
@@ -106,7 +105,6 @@
 //!         .await
 //!         .expect("Object placement database connection failure");
 //!     let object_placement_provider = SqlObjectPlacementProvider::new(pool);
-//!     object_placement_provider.migrate().await;
 //!
 //!     // Create the server object
 //!     let mut server = Server::new(
@@ -115,6 +113,7 @@
 //!         membership_provider,
 //!         object_placement_provider,
 //!     );
+//!     server.prepare().await;
 //!
 //!     // Run the server
 //!     // server.run().await;
@@ -164,7 +163,7 @@
 //!         .connect("sqlite::memory:")
 //!         .await?;
 //!     let members_storage = SqlMembersStorage::new(pool);
-//!     # members_storage.migrate().await;
+//!     # members_storage.prepare().await;
 //!
 //!     // Create the client
 //!     let mut client = ClientBuilder::new()
@@ -199,6 +198,7 @@ pub mod registry;
 pub mod server;
 pub mod service;
 pub mod service_object;
+pub mod sql_migration;
 pub mod state;
 pub mod tap_err;
 

--- a/rio-rs/src/object_placement/migrations/0001-postgres-init.sql
+++ b/rio-rs/src/object_placement/migrations/0001-postgres-init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS object_placement
+(
+    struct_name     TEXT                NOT NULL,
+    object_id       TEXT                NOT NULL,
+    server_address  TEXT                NULL,
+
+    PRIMARY KEY (struct_name, object_id)
+);
+CREATE INDEX IF NOT EXISTS idx_object_placement_server_address on object_placement(server_address);

--- a/rio-rs/src/object_placement/migrations/0001-sqlite-init.sql
+++ b/rio-rs/src/object_placement/migrations/0001-sqlite-init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS object_placement
+(
+    struct_name     TEXT                NOT NULL,
+    object_id       TEXT                NOT NULL,
+    server_address  TEXT                NULL,
+
+    PRIMARY KEY (struct_name, object_id)
+);
+CREATE INDEX IF NOT EXISTS idx_object_placement_server_address on object_placement(server_address);

--- a/rio-rs/src/object_placement/mod.rs
+++ b/rio-rs/src/object_placement/mod.rs
@@ -28,6 +28,9 @@ impl ObjectPlacement {
 /// This is pretty much a CRUD for the mapping
 #[async_trait]
 pub trait ObjectPlacementProvider: Send + Sync + Clone {
+    /// Setup step, one can define it for their [ObjectPlacementProvider] so it does some
+    /// prep work before the server is running
+    async fn prepare(&self) {}
     /// Insert or update the object placement
     async fn update(&self, object_placement: ObjectPlacement);
     /// Find the server address for a given object

--- a/rio-rs/src/object_placement/mod.rs
+++ b/rio-rs/src/object_placement/mod.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use crate::ObjectId;
 
 pub mod local;
+pub mod redis;
 pub mod sql;
 
 /// Struct providing placement information

--- a/rio-rs/src/object_placement/redis.rs
+++ b/rio-rs/src/object_placement/redis.rs
@@ -1,0 +1,76 @@
+//! SQL implementation of the trait [ObjectPlacementProvider] to work with relational databases
+//!
+//! This uses [sqlx] under the hood
+
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use bb8_redis::{bb8::Pool, RedisConnectionManager};
+use redis::AsyncCommands;
+
+use super::{ObjectPlacement, ObjectPlacementProvider};
+use crate::ObjectId;
+
+#[derive(Clone)]
+pub struct RedisObjectPlacementProvider {
+    pool: Pool<RedisConnectionManager>,
+    key_prefix: String,
+}
+
+impl RedisObjectPlacementProvider {
+    pub async fn from_connect_string(connection_string: &str, key_prefix: Option<String>) -> Self {
+        let conn_manager = RedisConnectionManager::new(connection_string).expect("TODO");
+        let pool = Pool::builder().build(conn_manager).await.expect("TODO");
+        let key_prefix = key_prefix.unwrap_or_default();
+        Self { pool, key_prefix }
+    }
+}
+
+#[async_trait]
+impl ObjectPlacementProvider for RedisObjectPlacementProvider {
+    async fn update(&self, object_placement: ObjectPlacement) {
+        let object_id = format!(
+            "{}:{}",
+            object_placement.object_id.0, object_placement.object_id.1
+        );
+        let k1 = format!("{}{}", self.key_prefix, object_id);
+        let mut client = self.pool.get().await.expect("TODO");
+
+        if let Some(server_address) = object_placement.server_address {
+            let k2 = format!("{}{}", self.key_prefix, server_address);
+            let mut pipe = redis::pipe();
+            pipe.set(&k1, &server_address).sadd(&k2, &object_id);
+            let _: () = pipe.exec_async(&mut *client).await.expect("TODO");
+        } else {
+            // If there is no server associated with the allocation
+            // it means we can remove the placement associated with the object
+            let _: () = client.del(&k1).await.expect("TODO: delete");
+        }
+    }
+
+    async fn lookup(&self, object_id: &ObjectId) -> Option<String> {
+        let k = format!("{}{}:{}", self.key_prefix, object_id.0, object_id.1);
+        let mut client = self.pool.get().await.expect("TODO");
+        let placement: Option<String> = client.get(&k).await.expect("TODO");
+        placement
+    }
+
+    async fn clean_server(&self, address: String) {
+        let k = format!("{}{}", self.key_prefix, address);
+        let mut client = self.pool.get().await.expect("TODO");
+        let objects_in_server: HashSet<String> =
+            client.smembers(&k).await.expect("TODO: List objects");
+        for object_id in objects_in_server.iter() {
+            let k = format!("{}{}", self.key_prefix, object_id);
+            let _: () = client.del(&k).await.expect("TODO: clean object placement");
+        }
+        let _: () = client.del(&k).await.expect("TODO: delete server alloc");
+    }
+
+    async fn remove(&self, object_id: &ObjectId) {
+        let object_id = format!("{}:{}", object_id.0, object_id.1);
+        let k = format!("{}{}", self.key_prefix, object_id);
+        let mut client = self.pool.get().await.expect("TODO");
+        let _: () = client.del(&k).await.expect("TODO: clean object placement");
+    }
+}

--- a/rio-rs/src/protocol.rs
+++ b/rio-rs/src/protocol.rs
@@ -99,6 +99,9 @@ pub enum ClientError {
     #[error("the requested server is not available")]
     ServerNotAvailable(String),
 
+    #[error("client was disconnected from the server (no more items on the TCP stream)")]
+    Disconnect,
+
     #[error("rendenvouz is not available")]
     RendevouzUnavailable,
 

--- a/rio-rs/src/protocol.rs
+++ b/rio-rs/src/protocol.rs
@@ -61,6 +61,9 @@ pub enum ResponseError {
     #[error("ServiceObject had to be deallocated")]
     DeallocateServiceObject,
 
+    #[error("ServiceObject could not be allocated")]
+    Allocate,
+
     #[error("unknown execution error")]
     Unknown(String),
 

--- a/rio-rs/src/registry.rs
+++ b/rio-rs/src/registry.rs
@@ -319,10 +319,17 @@ mod test {
     #[tokio::test]
     async fn sanity_check() {
         fn is_sync<T: Sync>(_t: T) {}
+        fn is_send<T: Send>(_t: T) {}
+
         is_sync(Human::default());
         is_sync(HiMessage {});
         is_sync(Registry::new());
         is_sync(Box::new(Registry::new()));
+
+        is_send(Human::default());
+        is_send(HiMessage {});
+        is_send(Registry::new());
+        is_send(Box::new(Registry::new()));
 
         let mut registry = Registry::new();
         let obj = Human::default();

--- a/rio-rs/src/registry.rs
+++ b/rio-rs/src/registry.rs
@@ -5,6 +5,7 @@
 use crate::{app_data::AppData, errors::HandlerError, WithId};
 use async_trait::async_trait;
 use dashmap::DashMap;
+use log::warn;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     any::{type_name, Any},
@@ -144,10 +145,20 @@ impl Registry {
     /// remove object from registry
     pub async fn remove(&self, type_id: String, object_id: String) {
         let key = (type_id, object_id);
-        self.object_map.remove(&key).map(|(_, _)| ()).or_else(|| {
-            println!("TODO: error deleting {:?}", key);
-            Some(())
-        });
+
+        if let None = self.object_map.remove(&key) {
+            warn!(
+                "Failed to remove object from mapping ({:?} not present)",
+                key
+            );
+        }
+
+        if let None = self.handler_map.remove(&key) {
+            warn!(
+                "Failed to remove handler from mapping ({:?} not present)",
+                key
+            );
+        }
     }
 }
 

--- a/rio-rs/src/server.rs
+++ b/rio-rs/src/server.rs
@@ -210,6 +210,12 @@ where
         }
     }
 
+    pub async fn prepare(&self) {
+        self.cluster_provider.members_storage().prepare().await;
+        let object_placement_provider_guard = self.object_placement_provider.read().await;
+        object_placement_provider_guard.prepare().await;
+    }
+
     pub fn app_data<Data>(&mut self, data: Data)
     where
         Data: Send + Sync + 'static,

--- a/rio-rs/src/server.rs
+++ b/rio-rs/src/server.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use bb8::Pool;
 use derive_builder::Builder;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 use tokio::{net::TcpListener, sync::RwLock};
 use tower::ServiceExt;
 
@@ -26,6 +27,7 @@ use crate::ObjectId;
 /// Internal commands, e.g., shutdown a service object
 #[derive(Debug)]
 pub enum AdminCommands {
+    ServerExit,
     // Shutdown(hander_type, handler_id)
     Shutdown(String, String),
 }
@@ -59,6 +61,10 @@ where
     /// TCP listener for the main server
     #[builder(setter(skip))]
     listener: Option<TcpListener>,
+
+    /// We store all the join handlers so we can terminate them once the server dies
+    #[builder(setter(skip))]
+    serivce_join_handlers: RwLock<Vec<JoinHandle<()>>>,
 
     registry: Arc<RwLock<Registry>>,
     cluster_provider: C,
@@ -206,6 +212,7 @@ where
             app_data: Arc::new(AppData::new()),
             client_pool_size: 3,
             listener: None,
+            serivce_join_handlers: RwLock::new(vec![]),
             _marker: PhantomData {},
         }
     }
@@ -275,12 +282,25 @@ where
                 accept_result?;
             }
             cluster_provider_serve_result = self.cluster_provider.serve(&local_addr)  => {
-                cluster_provider_serve_result.map_err(ServerError::ClusterProviderServe)?;
+                if let Err(e) = cluster_provider_serve_result {
+                    eprintln!("Error on cluster provider serve");
+                    eprintln!("  {:?}", e);
+                    return Err(ServerError::ClusterProviderServe(e));
+                }
             }
             _ = self.consume_admin_commands(admin_receiver) => {
-                println!("admin command serve finished first");
+                eprintln!("[{}] Admin command serve finished first", local_addr);
             }
         };
+
+        // Gracefuly abort all the tasks that are receiving messages for the running ServiceObjects
+        println!("[{}] Stopping server", local_addr);
+        let service_join_handlers = self.serivce_join_handlers.read().await;
+        for i in service_join_handlers.iter() {
+            i.abort();
+        }
+        println!("[{}] Server stopped", local_addr);
+
         Ok(())
     }
 
@@ -288,7 +308,7 @@ where
         let listener = self.listener.as_ref().ok_or(ServerError::Bind(
             "Socket not bind before accept connection".to_string(),
         ))?;
-        println!("Listening on: {:?}", listener.local_addr());
+        println!("Listening on `{:?}`", listener.local_addr());
 
         loop {
             let (stream, _) = listener.accept().await.map_err(|_| ServerError::Run)?;
@@ -301,15 +321,25 @@ where
                 .await
                 .map_err(|_| ServerError::Run)?;
 
-            tokio::spawn(async move { service.run(stream).await });
+            let service_run_join_handler = tokio::spawn(async move { service.run(stream).await });
+            self.serivce_join_handlers
+                .write()
+                .await
+                .push(service_run_join_handler);
         }
     }
 
+    /// Receives the messages from the AdminReceiver channel
+    ///
+    /// These are operations that need to be protected from external access, and only
+    /// ServiceObjects have access to this channel - the channel is in the AppData
     async fn consume_admin_commands(&self, mut admin_receiver: AdminReceiver) {
         while let Some(message) = admin_receiver.recv().await {
             match message {
+                // TODO I think this only works for the current server,
+                //      meaning, if the service object is running on another
+                //      node, it won't shutdown
                 AdminCommands::Shutdown(object_kind, object_id) => {
-                    println!("deleting {}.{}", object_kind, object_id);
                     let registry = self.registry.write().await;
                     registry
                         .remove(object_kind.clone(), object_id.clone())
@@ -319,7 +349,10 @@ where
                         .await
                         .remove(&ObjectId(object_kind, object_id))
                         .await;
-                    println!("done deleting");
+                }
+                AdminCommands::ServerExit => {
+                    // Exists `while` to terminate the server
+                    return;
                 }
             }
         }

--- a/rio-rs/src/service_object.rs
+++ b/rio-rs/src/service_object.rs
@@ -19,6 +19,7 @@ use crate::state::ObjectStateManager;
 ///
 /// It is stuct name + the object id (as in [WithId]).
 /// It is used lookups across tthis project
+#[derive(Debug)]
 pub struct ObjectId(pub String, pub String);
 
 impl ObjectId {

--- a/rio-rs/src/sql_migration.rs
+++ b/rio-rs/src/sql_migration.rs
@@ -1,0 +1,3 @@
+pub trait SqlMigrations {
+    fn queries() -> Vec<String>;
+}

--- a/rio-rs/src/state/local.rs
+++ b/rio-rs/src/state/local.rs
@@ -40,7 +40,7 @@ where
         if let Some(x) = self.data.get(&k) {
             Ok(serde_json::from_str(&x).expect("TODO"))
         } else {
-            Err(LoadStateError::Unknown)
+            Err(LoadStateError::ObjectNotFound)
         }
     }
 }

--- a/rio-rs/src/state/migrations/0001-postgres-init.sql
+++ b/rio-rs/src/state/migrations/0001-postgres-init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS state_provider_object_state
+(
+    object_kind       TEXT                              NOT NULL,
+    object_id         TEXT                              NOT NULL,
+    state_type        TEXT                              NOT NULL,
+    serialized_state  bytea                             NOT NULL,
+    PRIMARY KEY (object_kind, object_id, state_type)
+);
+

--- a/rio-rs/src/state/migrations/0001-sqlite-init.sql
+++ b/rio-rs/src/state/migrations/0001-sqlite-init.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS state_provider_object_state
+(
+    object_kind         TEXT                              NOT NULL,
+    object_id           TEXT                              NOT NULL,
+    state_type          TEXT                              NOT NULL,
+    serialized_state    BLOB                              NOT NULL,
+    PRIMARY KEY (object_kind, object_id, state_type)
+);

--- a/rio-rs/src/state/mod.rs
+++ b/rio-rs/src/state/mod.rs
@@ -24,6 +24,17 @@ where
     Self: Sync + Send,
     T: DeserializeOwned,
 {
+    /// <div class="warning">
+    /// TODO
+    ///
+    /// This here can't be used right now as it depends on the type `T` when
+    /// called.
+    ///
+    /// This makes its usage quite cluncky (if not impossible) as you need to invoke it
+    /// with a target of this loader
+    /// </div>
+    async fn prepare(&self) {}
+
     async fn load(
         &self,
         object_kind: &str,
@@ -60,6 +71,8 @@ where
 /// its original type
 #[async_trait]
 pub trait StateSaver: Sync + Send {
+    async fn prepare(&self) {}
+
     async fn save(
         &self,
         object_kind: &str,

--- a/rio-rs/src/state/mod.rs
+++ b/rio-rs/src/state/mod.rs
@@ -10,6 +10,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 pub mod local;
+pub mod redis;
 pub mod sql;
 
 /// The `StateLoader` defines an interface to load serialized state from a source

--- a/rio-rs/src/state/redis.rs
+++ b/rio-rs/src/state/redis.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+use bb8_redis::{bb8::Pool, RedisConnectionManager};
+use redis::AsyncCommands;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use super::{StateLoader, StateSaver};
+use crate::errors::LoadStateError;
+
+/// State Storage using Redis/Valkey
+#[derive(Clone)]
+pub struct RedisState {
+    pool: Pool<RedisConnectionManager>,
+    key_prefix: String,
+}
+
+impl RedisState {
+    pub async fn from_connect_string(connection_string: &str, key_prefix: Option<String>) -> Self {
+        let conn_manager = RedisConnectionManager::new(connection_string).expect("TODO");
+        let pool = Pool::builder().build(conn_manager).await.expect("TODO");
+        let key_prefix = key_prefix.unwrap_or_default();
+        Self { pool, key_prefix }
+    }
+}
+
+#[async_trait]
+impl<T> StateLoader<T> for RedisState
+where
+    T: DeserializeOwned,
+{
+    async fn load(
+        &self,
+        object_kind: &str,
+        object_id: &str,
+        state_type: &str,
+    ) -> Result<T, LoadStateError> {
+        let object_kind = object_kind.to_string();
+        let object_id = object_id.to_string();
+        let state_type = state_type.to_string();
+        let key = format!(
+            "{}state:{}:{}:{}",
+            self.key_prefix, object_kind, object_id, state_type
+        );
+        let mut client = self.pool.get().await.map_err(|_| LoadStateError::Unknown)?;
+        let se_data: Option<String> = client.get(key).await.expect("TODO");
+        if let Some(x) = se_data {
+            let data = serde_json::from_str(&x).map_err(|_| LoadStateError::DeserializationError);
+            data
+        } else {
+            Err(LoadStateError::ObjectNotFound)
+        }
+    }
+}
+
+#[async_trait]
+impl StateSaver for RedisState {
+    async fn save(
+        &self,
+        object_kind: &str,
+        object_id: &str,
+        state_type: &str,
+        data: &(impl Serialize + Send + Sync),
+    ) -> Result<(), LoadStateError> {
+        let object_kind = object_kind.to_string();
+        let object_id = object_id.to_string();
+        let state_type = state_type.to_string();
+        let key = format!(
+            "{}state:{}:{}:{}",
+            self.key_prefix, object_kind, object_id, state_type
+        );
+        let ser_data =
+            serde_json::to_string(&data).map_err(|_| LoadStateError::SerializationError)?;
+        let mut client = self.pool.get().await.map_err(|_| LoadStateError::Unknown)?;
+        let _: () = client
+            .set(key, ser_data)
+            .await
+            .map_err(|_| LoadStateError::Unknown)?;
+        Ok(())
+    }
+}

--- a/rio-rs/src/state/sql.rs
+++ b/rio-rs/src/state/sql.rs
@@ -1,4 +1,4 @@
-use crate::errors::LoadStateError;
+use crate::{errors::LoadStateError, sql_migration::SqlMigrations};
 use async_trait::async_trait;
 use futures::TryFutureExt;
 use serde::{de::DeserializeOwned, Serialize};
@@ -9,6 +9,24 @@ use sqlx::{
 };
 
 use super::{StateLoader, StateSaver};
+
+pub struct PgStageMigrations {}
+
+impl SqlMigrations for PgStageMigrations {
+    fn queries() -> Vec<String> {
+        let migration_001 = include_str!("./migrations/0001-postgres-init.sql");
+        vec![migration_001.to_string()]
+    }
+}
+
+pub struct SqliteStateMigrations {}
+
+impl SqlMigrations for SqliteStateMigrations {
+    fn queries() -> Vec<String> {
+        let migration_001 = include_str!("./migrations/0001-sqlite-init.sql");
+        vec![migration_001.to_string()]
+    }
+}
 
 #[derive(Debug)]
 pub struct SqlState {
@@ -26,20 +44,13 @@ impl SqlState {
 
     pub async fn migrate(&self) {
         let mut transaction = self.pool.begin().await.unwrap();
-
-        let queries = [
-            // Table with all state objects
-            r#"CREATE TABLE IF NOT EXISTS state_provider_object_state
-               (
-                   object_kind       TEXT                              NOT NULL,
-                   object_id         TEXT                              NOT NULL,
-                   state_type       TEXT                              NOT NULL,
-                   serialized_state BLOB                              NOT NULL,
-                   PRIMARY KEY (object_kind, object_id, state_type)
-               )"#,
-        ];
+        let queries = if let Some(_) = self.pool.connect_options().as_postgres() {
+            PgStageMigrations::queries()
+        } else {
+            SqliteStateMigrations::queries()
+        };
         for query in queries {
-            sqlx::query(query).execute(&mut transaction).await.unwrap();
+            sqlx::query(&query).execute(&mut transaction).await.unwrap();
         }
         transaction.commit().await.unwrap();
     }
@@ -50,6 +61,10 @@ impl<T> StateLoader<T> for SqlState
 where
     T: DeserializeOwned,
 {
+    async fn prepare(&self) {
+        self.migrate().await;
+    }
+
     async fn load(
         &self,
         object_kind: &str,
@@ -77,6 +92,10 @@ where
 
 #[async_trait]
 impl StateSaver for SqlState {
+    async fn prepare(&self) {
+        self.migrate().await;
+    }
+
     async fn save(
         &self,
         object_kind: &str,
@@ -96,7 +115,7 @@ impl StateSaver for SqlState {
         .bind(object_kind)
         .bind(object_id)
         .bind(state_type)
-        .bind(serialized_data)
+        .bind(serialized_data.bytes().collect::<Vec<_>>())
         .execute(&self.pool)
         .map_err(|_| LoadStateError::Unknown)
         .await

--- a/rio-rs/src/state/sql.rs
+++ b/rio-rs/src/state/sql.rs
@@ -81,7 +81,10 @@ where
         .bind(object_kind)
         .bind(object_id)
         .bind(state_type)
-        .map(|x: AnyRow| -> String { x.get("serialized_state") })
+        .map(|x: AnyRow| -> String {
+            let tmp = x.get::<Vec<u8>, _>("serialized_state");
+            String::from_utf8(tmp).expect("TODO")
+        })
         .fetch_one(&self.pool)
         .map_err(|_| LoadStateError::ObjectNotFound)
         .await?;
@@ -117,7 +120,10 @@ impl StateSaver for SqlState {
         .bind(state_type)
         .bind(serialized_data.bytes().collect::<Vec<_>>())
         .execute(&self.pool)
-        .map_err(|_| LoadStateError::Unknown)
+        .map_err(|e| {
+            eprintln!("{:?}", e);
+            LoadStateError::Unknown
+        })
         .await
         .map(|_| ())
     }

--- a/rio-rs/tests/client_server_integration_test.rs
+++ b/rio-rs/tests/client_server_integration_test.rs
@@ -1,10 +1,11 @@
 use async_trait::async_trait;
-use futures::{pin_mut, Future, StreamExt};
+use futures::{pin_mut, StreamExt};
 use rio_macros::{Message, TypeName, WithId};
 
 use rio_rs::app_data::AppDataExt;
 use rio_rs::cluster::storage::local::LocalStorage;
 use rio_rs::message_router::MessageRouter;
+use rio_rs::object_placement::local::LocalObjectPlacementProvider;
 use rio_rs::prelude::*;
 use rio_rs::protocol::pubsub::SubscriptionResponse;
 use rio_rs::registry::IdentifiableType;
@@ -13,7 +14,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 
-use rio_rs::object_placement::local::LocalObjectPlacementProvider;
+mod server_utils;
+use server_utils::run_integration_test;
 
 #[derive(Default, WithId, TypeName)]
 struct MockService {
@@ -69,206 +71,186 @@ impl Handler<CausePublishMessage> for MockService {
     }
 }
 
-type LocalServer =
-    Server<LocalStorage, PeerToPeerClusterProvider<LocalStorage>, LocalObjectPlacementProvider>;
-
-async fn build_server(
-    members_storage: LocalStorage,
-    object_placement_provider: LocalObjectPlacementProvider,
-) -> LocalServer {
+fn build_registry() -> Registry {
     let mut registry = Registry::new();
     registry.add_type::<MockService>();
     registry.add_handler::<MockService, MockMessage>();
     registry.add_handler::<MockService, CausePublishMessage>();
-
-    let membership_provider =
-        PeerToPeerClusterProvider::new(members_storage.clone(), Default::default());
-    let mut server = Server::new(
-        "0.0.0.0:0".to_string(),
-        registry,
-        membership_provider,
-        object_placement_provider,
-    );
-    server.bind().await.expect("Bind Error");
-    server
-}
-
-// Run a test and fail if it takes more then `timeout_seconds`
-async fn run_integration_test<Fut>(
-    timeout_seconds: u64,
-    members_storage: LocalStorage,
-    num_servers: usize,
-    test_fn: impl FnOnce() -> Fut,
-) where
-    Fut: Future<Output = ()>,
-{
-    let mut servers = vec![];
-    let object_placement_provider = LocalObjectPlacementProvider::default();
-
-    for _ in 0..num_servers {
-        let server = build_server(members_storage.clone(), object_placement_provider.clone()).await;
-        servers.push(server);
-    }
-
-    let test_fn_with_members = || async move {
-        // Wait for cluster membership storage has some active servers
-        while members_storage.active_members().await.unwrap().len() == 0 {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
-        test_fn().await;
-    };
-
-    let server_futures: Vec<_> = servers.iter_mut().map(|s| s.run()).collect();
-    let servers_single_future = futures::future::join_all(server_futures);
-
-    tokio::select! {
-        _ = servers_single_future => {
-            panic!("A server has died");
-        }
-        _ = test_fn_with_members() => {}
-        _ = tokio::time::sleep(Duration::from_secs(timeout_seconds)) => {
-            panic!("Timeout reached");
-        }
-    };
+    registry
 }
 
 #[tokio::test]
 async fn request_response() {
     let members_storage = LocalStorage::default();
-    run_integration_test(5, members_storage.clone(), 1, || async move {
-        let mut client = ClientBuilder::new()
-            .members_storage(members_storage)
-            .build()
-            .unwrap();
-        let message = MockMessage {
-            text: "hi".to_string(),
-        };
-        let resp: MockResponse = client.send("MockService", "1", &message).await.unwrap();
-        assert_eq!(&resp.text, "1 received hi");
-    })
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        1,
+        || async move {
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage)
+                .build()
+                .unwrap();
+            let message = MockMessage {
+                text: "hi".to_string(),
+            };
+            let resp: MockResponse = client.send("MockService", "1", &message).await.unwrap();
+            assert_eq!(&resp.text, "1 received hi");
+        },
+    )
     .await;
 }
 
 #[tokio::test]
 async fn request_response_redirectt() {
     let members_storage = LocalStorage::default();
-    run_integration_test(5, members_storage.clone(), 10, || async move {
-        let mut client = ClientBuilder::new()
-            .members_storage(members_storage)
-            .build()
-            .unwrap();
-        let message = MockMessage {
-            text: "hi".to_string(),
-        };
-        let resp: MockResponse = client.send("MockService", "1", &message).await.unwrap();
-        assert_eq!(&resp.text, "1 received hi");
-    })
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        10,
+        || async move {
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage)
+                .build()
+                .unwrap();
+            let message = MockMessage {
+                text: "hi".to_string(),
+            };
+            let resp: MockResponse = client.send("MockService", "1", &message).await.unwrap();
+            assert_eq!(&resp.text, "1 received hi");
+        },
+    )
     .await;
 }
 
 #[tokio::test]
 async fn pubsub() {
     let members_storage = LocalStorage::default();
-    run_integration_test(5, members_storage.clone(), 1, || async move {
-        let another_members_storage = members_storage.clone();
-        let publishing_task = tokio::spawn(async move {
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        1,
+        || async move {
+            let another_members_storage = members_storage.clone();
+            let publishing_task = tokio::spawn(async move {
+                let mut client = ClientBuilder::new()
+                    .members_storage(another_members_storage)
+                    .build()
+                    .unwrap();
+
+                for i in 0..10 {
+                    let _: () = client
+                        .send(
+                            "MockService",
+                            "1",
+                            &CausePublishMessage {
+                                text: format!("hey {}", i),
+                            },
+                        )
+                        .await
+                        .unwrap();
+                }
+            });
             let mut client = ClientBuilder::new()
-                .members_storage(another_members_storage)
+                .members_storage(members_storage)
                 .build()
                 .unwrap();
 
-            for i in 0..10 {
-                let _: () = client
-                    .send(
-                        "MockService",
-                        "1",
-                        &CausePublishMessage {
-                            text: format!("hey {}", i),
-                        },
-                    )
-                    .await
-                    .unwrap();
+            let resp = client
+                .subscribe::<CausePublishMessage>("MockService", "1")
+                .await;
+
+            pin_mut!(resp);
+
+            let mut recv_count = 0;
+            // it will timeout if it doesn't get the last message
+            while let Some(Ok(i)) = resp.next().await {
+                recv_count += 1;
+                if i.text == "hey 9" {
+                    break;
+                }
             }
-        });
-        let mut client = ClientBuilder::new()
-            .members_storage(members_storage)
-            .build()
-            .unwrap();
-
-        let resp = client
-            .subscribe::<CausePublishMessage>("MockService", "1")
-            .await;
-
-        pin_mut!(resp);
-
-        let mut recv_count = 0;
-        // it will timeout if it doesn't get the last message
-        while let Some(Ok(i)) = resp.next().await {
-            recv_count += 1;
-            if i.text == "hey 9" {
-                break;
-            }
-        }
-        assert!(recv_count > 0);
-        publishing_task.abort();
-    })
+            assert!(recv_count > 0);
+            publishing_task.abort();
+        },
+    )
     .await;
 }
 
 #[tokio::test]
 async fn pubsub_redirect() {
     let members_storage = LocalStorage::default();
-    run_integration_test(15, members_storage.clone(), 10, || async move {
-        let another_members_storage = members_storage.clone();
+    let object_placement_provider = LocalObjectPlacementProvider::default();
 
-        let publishing_task = tokio::spawn(async move {
+    run_integration_test(
+        15,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        10,
+        || async move {
+            let another_members_storage = members_storage.clone();
+
+            let publishing_task = tokio::spawn(async move {
+                let mut client = ClientBuilder::new()
+                    .members_storage(another_members_storage)
+                    .build()
+                    .unwrap();
+
+                for i in 0..100 {
+                    let _: () = client
+                        .send(
+                            "MockService",
+                            "1",
+                            &CausePublishMessage {
+                                text: format!("hey {}", i),
+                            },
+                        )
+                        .await
+                        .expect("Send Error");
+                }
+            });
+
             let mut client = ClientBuilder::new()
-                .members_storage(another_members_storage)
+                .members_storage(members_storage)
                 .build()
-                .unwrap();
+                .expect("Client Build Error");
 
-            for i in 0..100 {
-                let _: () = client
-                    .send(
-                        "MockService",
-                        "1",
-                        &CausePublishMessage {
-                            text: format!("hey {}", i),
-                        },
-                    )
-                    .await
-                    .expect("Send Error");
+            // Hack to try to cause a redirect
+            // This test can have false positives if there is no redirect
+            sleep(Duration::from_millis(10)).await;
+            let subscription = client
+                .subscribe::<CausePublishMessage>("MockService", "1")
+                .await;
+            pin_mut!(subscription);
+
+            // it will timeout if it doesn't get the last message
+            let mut recv_count = 0;
+            while let Some(message_result) = subscription.next().await {
+                let i = if let Ok(message) = message_result {
+                    message
+                } else {
+                    break;
+                };
+                recv_count += 1;
+                if i.text == "hey 99" {
+                    break;
+                }
             }
-        });
-
-        let mut client = ClientBuilder::new()
-            .members_storage(members_storage)
-            .build()
-            .expect("Client Build Error");
-
-        // Hack to try to cause a redirect
-        // This test can have false positives if there is no redirect
-        sleep(Duration::from_millis(10)).await;
-        let subscription = client
-            .subscribe::<CausePublishMessage>("MockService", "1")
-            .await;
-        pin_mut!(subscription);
-
-        // it will timeout if it doesn't get the last message
-        let mut recv_count = 0;
-        while let Some(message_result) = subscription.next().await {
-            let i = if let Ok(message) = message_result {
-                message
-            } else {
-                break;
-            };
-            recv_count += 1;
-            if i.text == "hey 99" {
-                break;
-            }
-        }
-        assert!(recv_count > 0);
-        publishing_task.abort();
-    })
+            assert!(recv_count > 0);
+            publishing_task.abort();
+        },
+    )
     .await;
 }

--- a/rio-rs/tests/cluster_storage_backend.rs
+++ b/rio-rs/tests/cluster_storage_backend.rs
@@ -1,0 +1,99 @@
+use rio_rs::{cluster::storage::Member, prelude::MembersStorage};
+
+mod db_utils;
+
+async fn members_sanity_check<T: MembersStorage>(storage: T) {
+    storage.prepare().await;
+
+    let members = storage.members().await.unwrap();
+    assert_eq!(members.len(), 0);
+
+    storage
+        .push(Member::new("0.0.0.0".to_string(), "9090".to_string()))
+        .await
+        .unwrap();
+
+    let members = storage.members().await.unwrap();
+    assert_eq!(members.len(), 1);
+
+    storage.set_active("0.0.0.0", "9090").await.unwrap();
+    let members = storage.active_members().await.unwrap();
+    assert_eq!(members.len(), 1);
+
+    storage.set_inactive("0.0.0.0", "9090").await.unwrap();
+    let members = storage.active_members().await.unwrap();
+    assert_eq!(members.len(), 0);
+}
+
+async fn failures_sanity_check<T: MembersStorage>(storage: T) {
+    storage.prepare().await;
+
+    let failures = storage.member_failures("0.0.0.0", "9090").await.unwrap();
+    assert_eq!(failures.len(), 0);
+
+    storage.notify_failure("0.0.0.0", "9090").await.unwrap();
+
+    let failures = storage.member_failures("0.0.0.0", "9090").await.unwrap();
+    assert_eq!(failures.len(), 1);
+}
+
+mod redis {
+    use rio_rs::cluster::storage::redis::RedisMembersStorage;
+
+    #[tokio::test]
+    async fn members_sanity_check() {
+        let prefix = chrono::Local::now().timestamp().to_string();
+        let storage =
+            RedisMembersStorage::from_connect_string("redis://localhost:16379", Some(prefix)).await;
+        super::members_sanity_check(storage).await;
+    }
+
+    #[tokio::test]
+    async fn failures_sanity_check() {
+        let prefix = chrono::Local::now().timestamp().to_string();
+        let storage =
+            RedisMembersStorage::from_connect_string("redis://localhost:16379", Some(prefix)).await;
+        super::failures_sanity_check(storage).await;
+    }
+}
+
+mod sqlite {
+    use super::db_utils::sqlite::pool;
+    use rio_rs::cluster::storage::sql::SqlMembersStorage;
+
+    #[tokio::test]
+    async fn members_sanity_check() {
+        let pool = pool().await;
+        let storage = SqlMembersStorage::new(pool);
+        super::members_sanity_check(storage).await;
+    }
+
+    #[tokio::test]
+    async fn failures_sanity_check() {
+        let pool = SqlMembersStorage::pool()
+            .connect("sqlite://:memory:")
+            .await
+            .unwrap();
+        let storage = SqlMembersStorage::new(pool);
+        super::failures_sanity_check(storage).await;
+    }
+}
+
+mod pgsql {
+    use super::db_utils::pgsql::pool;
+    use rio_rs::cluster::storage::sql::SqlMembersStorage;
+
+    #[tokio::test]
+    async fn members_sanity_check() {
+        let pool = pool("members_sanity_check").await;
+        let storage = SqlMembersStorage::new(pool);
+        super::members_sanity_check(storage).await;
+    }
+
+    #[tokio::test]
+    async fn failures_sanity_check() {
+        let pool = pool("failure_sanity_check").await;
+        let storage = SqlMembersStorage::new(pool);
+        super::failures_sanity_check(storage).await;
+    }
+}

--- a/rio-rs/tests/db_utils.rs
+++ b/rio-rs/tests/db_utils.rs
@@ -1,0 +1,39 @@
+use rio_rs::state::sql::SqlState;
+use sqlx::{any::AnyPoolOptions, Any, Pool};
+
+#[allow(dead_code)]
+pub(crate) mod pgsql {
+    use super::*;
+
+    pub(crate) async fn pool(name: &str) -> Pool<Any> {
+        let pool = AnyPoolOptions::new()
+            .connect("postgres://test:test@localhost:15432/test")
+            .await
+            .unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
+        let sql = format!("DROP DATABASE IF EXISTS {name};");
+        sqlx::query(&sql).execute(&mut conn).await.unwrap();
+
+        let sql = format!("CREATE DATABASE {name} WITH OWNER=test;");
+        sqlx::query(&sql).execute(&mut conn).await.unwrap();
+
+        let new_conn_str = format!("postgres://test:test@localhost:15432/{name}");
+        let pool = SqlState::pool().connect(&&new_conn_str).await.unwrap();
+        pool
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) mod sqlite {
+
+    use super::*;
+
+    pub(crate) async fn pool() -> Pool<Any> {
+        let pool = AnyPoolOptions::new()
+            .connect("sqlite://:memory:")
+            .await
+            .unwrap();
+        pool
+    }
+}

--- a/rio-rs/tests/object_allocation.rs
+++ b/rio-rs/tests/object_allocation.rs
@@ -1,0 +1,131 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rio_rs::object_placement::ObjectPlacementProvider;
+use rio_rs::server::AdminSender;
+use serde::{Deserialize, Serialize};
+
+use rio_rs::prelude::*;
+
+use rio_rs::cluster::storage::local::LocalStorage;
+use rio_rs::object_placement::local::LocalObjectPlacementProvider;
+
+mod server_utils;
+use server_utils::{is_allocated, run_integration_test};
+use tokio::time::sleep;
+
+#[derive(Default, Debug, Message, TypeName, Serialize, Deserialize)]
+struct OkMessage {}
+
+#[derive(Default, Debug, Message, TypeName, Serialize, Deserialize)]
+struct KillServer {}
+
+#[derive(Default, Debug, PartialEq, Message, TypeName, Serialize, Deserialize)]
+struct MockResponse {}
+
+#[derive(Debug, Default, WithId, TypeName, ManagedState)]
+struct MockService {
+    id: String,
+}
+
+#[async_trait]
+impl Handler<OkMessage> for MockService {
+    type Returns = MockResponse;
+    async fn handle(
+        &mut self,
+        _message: OkMessage,
+        _ctx: Arc<AppData>,
+    ) -> Result<Self::Returns, HandlerError> {
+        let resp = MockResponse {};
+        Ok(resp)
+    }
+}
+
+#[async_trait]
+impl Handler<KillServer> for MockService {
+    type Returns = MockResponse;
+    async fn handle(
+        &mut self,
+        _message: KillServer,
+        ctx: Arc<AppData>,
+    ) -> Result<Self::Returns, HandlerError> {
+        let admin_interface = ctx.get::<AdminSender>();
+        let _ = admin_interface.send(rio_rs::server::AdminCommands::ServerExit);
+        Ok(MockResponse {})
+    }
+}
+
+fn build_registry() -> Registry {
+    let mut registry = Registry::new();
+    registry.add_type::<MockService>();
+    registry.add_handler::<MockService, OkMessage>();
+    registry.add_handler::<MockService, KillServer>();
+    registry
+}
+
+// This test runs [move_object_on_server_failure_single] several times
+// to ensure it will try to pick up the same server even after it gets
+// terminated
+//
+// Unfortunetely this makes the test quite slow
+#[tokio::test]
+async fn move_object_on_server_failure() {
+    for _ in 0..10 {
+        move_object_on_server_failure_single().await;
+    }
+}
+
+async fn move_object_on_server_failure_single() {
+    let members_storage = LocalStorage::default();
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        20,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        2,
+        || async move {
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage.clone())
+                .build()
+                .unwrap();
+
+            let object_id = ObjectId::new("MockService", "1");
+            // Starts with the object not allocated
+            assert!(!is_allocated(&object_placement_provider, "MockService", "1").await);
+
+            // As soon as we send the first message, the object is allocated to a server
+            let message = OkMessage {};
+            client
+                .send::<MockResponse>("MockService", "1", &message)
+                .await
+                .unwrap();
+            assert!(is_allocated(&object_placement_provider, "MockService", "1").await);
+            let first_server = object_placement_provider.lookup(&object_id).await.unwrap();
+
+            // Now we send a message that will cause the server where this object is in to die.
+            // Notice we need to wait a few seconds so the cluster provider marks it as inactive
+            let message = KillServer {};
+            client
+                .send::<MockResponse>("MockService", "1", &message)
+                .await
+                .unwrap();
+            sleep(Duration::from_secs(5)).await;
+
+            // The first server is now dead, we send another message to the object
+            // so it gets re-allocated somewhere else in the cluster
+            let message = OkMessage {};
+            client
+                .send::<MockResponse>("MockService", "1", &message)
+                .await
+                .unwrap();
+            // let members = members_storage.members().await.unwrap();
+            assert!(is_allocated(&object_placement_provider, "MockService", "1").await);
+            let second_server = object_placement_provider.lookup(&object_id).await.unwrap();
+            assert_ne!(first_server, second_server);
+        },
+    )
+    .await;
+}

--- a/rio-rs/tests/object_placement_backend.rs
+++ b/rio-rs/tests/object_placement_backend.rs
@@ -1,0 +1,108 @@
+mod db_utils;
+
+use rio_rs::{
+    object_placement::{ObjectPlacement, ObjectPlacementProvider},
+    ObjectId,
+};
+
+async fn no_placement<S: ObjectPlacementProvider>(provider: S) {
+    provider.prepare().await;
+
+    let server_addr = provider.lookup(&ObjectId::new("obj", "1")).await;
+    assert!(server_addr.is_none());
+}
+
+async fn save_and_load<S: ObjectPlacementProvider>(provider: S) {
+    provider.prepare().await;
+
+    let obj_id = ObjectId::new("obj", "1");
+    let placement = ObjectPlacement::new(obj_id, Some("0.0.0.0:8888".to_string()));
+    provider.update(placement).await;
+
+    let server_addr = provider.lookup(&ObjectId::new("obj", "1")).await;
+    assert_eq!(server_addr.as_ref().unwrap(), "0.0.0.0:8888");
+
+    provider.clean_server("0.0.0.0:8888".to_string()).await;
+    let server_addr = provider.lookup(&ObjectId::new("obj", "1")).await;
+    assert!(server_addr.is_none());
+}
+
+mod redis {
+    use rio_rs::object_placement::redis::RedisObjectPlacementProvider;
+
+    #[tokio::test]
+    async fn no_placement() {
+        let prefix = chrono::Local::now().timestamp_micros().to_string();
+        let provider = RedisObjectPlacementProvider::from_connect_string(
+            "redis://localhost:16379",
+            Some(prefix),
+        )
+        .await;
+        super::no_placement(provider).await;
+    }
+
+    #[tokio::test]
+    async fn save_and_load() {
+        let prefix = chrono::Local::now().timestamp_micros().to_string();
+        let provider = RedisObjectPlacementProvider::from_connect_string(
+            "redis://localhost:16379",
+            Some(prefix),
+        )
+        .await;
+        super::save_and_load(provider).await;
+    }
+}
+
+mod sqlite {
+    use super::db_utils::sqlite::pool;
+    use rio_rs::object_placement::sql::SqlObjectPlacementProvider;
+
+    #[tokio::test]
+    async fn no_placement() {
+        let pool = pool().await;
+        let provider = SqlObjectPlacementProvider::new(pool);
+        super::no_placement(provider).await;
+    }
+
+    #[tokio::test]
+    async fn save_and_load() {
+        let pool = pool().await;
+        let provider = SqlObjectPlacementProvider::new(pool);
+        super::save_and_load(provider).await;
+    }
+}
+
+mod pgsql {
+    use super::db_utils::pgsql::pool;
+    use rio_rs::object_placement::sql::SqlObjectPlacementProvider;
+
+    #[tokio::test]
+    async fn no_placement() {
+        let pool = pool("no_placement").await;
+        let provider = SqlObjectPlacementProvider::new(pool);
+        super::no_placement(provider).await;
+    }
+
+    #[tokio::test]
+    async fn save_and_load() {
+        let pool = pool("save_and_load").await;
+        let provider = SqlObjectPlacementProvider::new(pool);
+        super::save_and_load(provider).await;
+    }
+}
+
+mod local {
+    use rio_rs::object_placement::local::LocalObjectPlacementProvider;
+
+    #[tokio::test]
+    async fn no_placement() {
+        let provider = LocalObjectPlacementProvider::default();
+        super::no_placement(provider).await;
+    }
+
+    #[tokio::test]
+    async fn save_and_load() {
+        let provider = LocalObjectPlacementProvider::default();
+        super::save_and_load(provider).await;
+    }
+}

--- a/rio-rs/tests/object_service_error_handling.rs
+++ b/rio-rs/tests/object_service_error_handling.rs
@@ -1,0 +1,158 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rio_rs::object_placement::local::LocalObjectPlacementProvider;
+use serde::{Deserialize, Serialize};
+
+use rio_macros::{Message, TypeName, WithId};
+use rio_rs::cluster::storage::local::LocalStorage;
+use rio_rs::prelude::*;
+
+mod server_utils;
+use server_utils::{is_allocated, run_integration_test};
+
+#[derive(Default, WithId, TypeName)]
+struct MockService {
+    id: String,
+}
+
+#[derive(Default, Debug, Message, TypeName, Serialize, Deserialize)]
+struct OkMessage {}
+
+#[derive(Default, Debug, Message, TypeName, Serialize, Deserialize)]
+struct ErrorMessage {}
+
+#[derive(Default, Debug, Message, TypeName, Serialize, Deserialize)]
+struct PanicMessage {}
+
+#[derive(Default, Debug, Message, TypeName, Serialize, Deserialize)]
+struct MockResponse {}
+
+#[async_trait]
+impl Handler<OkMessage> for MockService {
+    type Returns = MockResponse;
+    async fn handle(
+        &mut self,
+        _: OkMessage,
+        _: Arc<AppData>,
+    ) -> Result<Self::Returns, HandlerError> {
+        let resp = MockResponse {};
+        Ok(resp)
+    }
+}
+
+#[async_trait]
+impl Handler<ErrorMessage> for MockService {
+    type Returns = MockResponse;
+    async fn handle(
+        &mut self,
+        _: ErrorMessage,
+        _: Arc<AppData>,
+    ) -> Result<Self::Returns, HandlerError> {
+        Err(HandlerError::Unknown)
+    }
+}
+
+#[async_trait]
+impl Handler<PanicMessage> for MockService {
+    type Returns = MockResponse;
+    async fn handle(
+        &mut self,
+        _: PanicMessage,
+        _: Arc<AppData>,
+    ) -> Result<Self::Returns, HandlerError> {
+        panic!("Error handling message");
+    }
+}
+
+fn build_registry() -> Registry {
+    let mut registry = Registry::new();
+    registry.add_type::<MockService>();
+    registry.add_handler::<MockService, OkMessage>();
+    registry.add_handler::<MockService, ErrorMessage>();
+    registry.add_handler::<MockService, PanicMessage>();
+    registry
+}
+
+#[tokio::test]
+async fn service_is_allocated_ok() {
+    let members_storage = LocalStorage::default();
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        1,
+        || async move {
+            assert!(!is_allocated(&object_placement_provider, "MockService", "1").await);
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage)
+                .build()
+                .unwrap();
+            let message = OkMessage {};
+            let resp: Result<MockResponse, _> = client.send("MockService", "1", &message).await;
+            assert!(resp.is_ok());
+            assert!(is_allocated(&object_placement_provider, "MockService", "1").await);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn service_is_allocated_after_error() {
+    let members_storage = LocalStorage::default();
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        1,
+        || async move {
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage)
+                .build()
+                .unwrap();
+
+            assert!(!is_allocated(&object_placement_provider, "MockService", "1").await);
+
+            let message = ErrorMessage {};
+            let resp: Result<MockResponse, _> = client.send("MockService", "1", &message).await;
+            assert!(resp.is_err());
+            assert!(is_allocated(&object_placement_provider, "MockService", "1").await);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn service_is_not_allocated_after_panic() {
+    let members_storage = LocalStorage::default();
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        1,
+        || async move {
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage)
+                .build()
+                .unwrap();
+            assert!(!is_allocated(&object_placement_provider, "MockService", "1").await);
+
+            let message = PanicMessage {};
+            let resp: Result<MockResponse, _> = client.send("MockService", "1", &message).await;
+            assert!(resp.is_err());
+            assert!(!is_allocated(&object_placement_provider, "MockService", "1").await);
+        },
+    )
+    .await;
+}
+
+// TODO test for panic on pubsub?

--- a/rio-rs/tests/server_utils.rs
+++ b/rio-rs/tests/server_utils.rs
@@ -49,6 +49,7 @@ pub async fn run_integration_test<Fut>(
 ) where
     Fut: Future<Output = ()>,
 {
+    env_logger::try_init().ok();
     let mut servers = vec![];
 
     for _ in 0..num_servers {

--- a/rio-rs/tests/server_utils.rs
+++ b/rio-rs/tests/server_utils.rs
@@ -1,27 +1,32 @@
 use futures::Future;
+use std::time::Duration;
+
 use rio_rs::cluster::storage::local::LocalStorage;
 use rio_rs::object_placement::local::LocalObjectPlacementProvider;
 use rio_rs::object_placement::ObjectPlacementProvider;
 use rio_rs::prelude::Registry;
 use rio_rs::prelude::*;
 use rio_rs::server::Server;
-use std::time::Duration;
 
 pub type LocalServer =
     Server<LocalStorage, PeerToPeerClusterProvider<LocalStorage>, LocalObjectPlacementProvider>;
 
 pub type BuildRegistry = dyn Fn() -> Registry;
 
-pub type BuildServer =
-    dyn Fn(BuildRegistry, LocalStorage, LocalObjectPlacementProvider) -> LocalServer;
-
+#[allow(dead_code)] // It might be included on an integration test but not used
 async fn build_server(
     registry: Registry,
     members_storage: LocalStorage,
     object_placement_provider: LocalObjectPlacementProvider,
 ) -> LocalServer {
+    let mut cluster_provider_config = PeerToPeerClusterConfig::default();
+    // Test connectivity every second. If, for the past 10 seconds, it had more than 1 failure, the
+    // node will be marked as defective
+    cluster_provider_config.interval_secs = 1;
+    cluster_provider_config.num_failures_threshold = 3;
+    cluster_provider_config.interval_secs_threshold = 10;
     let membership_provider =
-        PeerToPeerClusterProvider::new(members_storage.clone(), Default::default());
+        PeerToPeerClusterProvider::new(members_storage.clone(), cluster_provider_config);
 
     let mut server = Server::new(
         "0.0.0.0:0".to_string(),
@@ -65,12 +70,20 @@ pub async fn run_integration_test<Fut>(
         test_fn().await;
     };
 
-    let server_futures: Vec<_> = servers.iter_mut().map(|s| s.run()).collect();
-    let servers_single_future = futures::future::join_all(server_futures);
+    let mut tasks = vec![];
+    for mut server in servers.into_iter() {
+        let task = tokio::spawn(async move {
+            let server_result = server.run().await;
+            drop(server);
+            server_result
+        });
+        tasks.push(task);
+    }
+    let servers_single_future = futures::future::join_all(tasks);
 
     tokio::select! {
         _ = servers_single_future => {
-            panic!("A server has died");
+            panic!("All servers have died");
         }
         _ = test_fn_with_members() => {}
         _ = tokio::time::sleep(Duration::from_secs(timeout_seconds)) => {
@@ -79,6 +92,7 @@ pub async fn run_integration_test<Fut>(
     };
 }
 
+#[allow(dead_code)] // It might be included on an integration test but not used
 pub async fn is_allocated(
     object_placement_provider: &impl ObjectPlacementProvider,
     service_type: impl ToString,

--- a/rio-rs/tests/server_utils.rs
+++ b/rio-rs/tests/server_utils.rs
@@ -1,0 +1,90 @@
+use futures::Future;
+use rio_rs::cluster::storage::local::LocalStorage;
+use rio_rs::object_placement::local::LocalObjectPlacementProvider;
+use rio_rs::object_placement::ObjectPlacementProvider;
+use rio_rs::prelude::Registry;
+use rio_rs::prelude::*;
+use rio_rs::server::Server;
+use std::time::Duration;
+
+pub type LocalServer =
+    Server<LocalStorage, PeerToPeerClusterProvider<LocalStorage>, LocalObjectPlacementProvider>;
+
+pub type BuildRegistry = dyn Fn() -> Registry;
+
+pub type BuildServer =
+    dyn Fn(BuildRegistry, LocalStorage, LocalObjectPlacementProvider) -> LocalServer;
+
+async fn build_server(
+    registry: Registry,
+    members_storage: LocalStorage,
+    object_placement_provider: LocalObjectPlacementProvider,
+) -> LocalServer {
+    let membership_provider =
+        PeerToPeerClusterProvider::new(members_storage.clone(), Default::default());
+
+    let mut server = Server::new(
+        "0.0.0.0:0".to_string(),
+        registry,
+        membership_provider,
+        object_placement_provider,
+    );
+    server.bind().await.expect("Bind Error");
+    server
+}
+
+// Run a test and fail if it takes more then `timeout_seconds`
+pub async fn run_integration_test<Fut>(
+    timeout_seconds: u64,
+    registry_builder: &BuildRegistry,
+    members_storage: LocalStorage,
+    object_placement_provider: LocalObjectPlacementProvider,
+    num_servers: usize,
+    test_fn: impl FnOnce() -> Fut,
+) where
+    Fut: Future<Output = ()>,
+{
+    let mut servers = vec![];
+
+    for _ in 0..num_servers {
+        let registry = registry_builder();
+        let server = build_server(
+            registry,
+            members_storage.clone(),
+            object_placement_provider.clone(),
+        )
+        .await;
+        servers.push(server);
+    }
+
+    let test_fn_with_members = || async move {
+        // Wait for cluster membership storage has some active servers
+        while members_storage.active_members().await.unwrap().len() == 0 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        test_fn().await;
+    };
+
+    let server_futures: Vec<_> = servers.iter_mut().map(|s| s.run()).collect();
+    let servers_single_future = futures::future::join_all(server_futures);
+
+    tokio::select! {
+        _ = servers_single_future => {
+            panic!("A server has died");
+        }
+        _ = test_fn_with_members() => {}
+        _ = tokio::time::sleep(Duration::from_secs(timeout_seconds)) => {
+            panic!("Timeout reached");
+        }
+    };
+}
+
+pub async fn is_allocated(
+    object_placement_provider: &impl ObjectPlacementProvider,
+    service_type: impl ToString,
+    service_id: impl ToString,
+) -> bool {
+    let object_id = ObjectId(service_type.to_string(), service_id.to_string());
+    let where_is_it = object_placement_provider.lookup(&object_id).await;
+    where_is_it.is_some()
+}

--- a/rio-rs/tests/service_lifecycle.rs
+++ b/rio-rs/tests/service_lifecycle.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use rio_rs::prelude::*;
+
+use rio_rs::cluster::storage::local::LocalStorage;
+use rio_rs::object_placement::local::LocalObjectPlacementProvider;
+use rio_rs::state::local::LocalState;
+
+mod server_utils;
+use server_utils::{is_allocated, run_integration_test};
+
+#[derive(Default, Debug, Message, TypeName, Serialize, Deserialize)]
+struct OkMessage {}
+
+#[derive(Default, Debug, PartialEq, Message, TypeName, Serialize, Deserialize)]
+struct MockResponse {}
+
+#[derive(Debug, Default, TypeName, Serialize, Deserialize)]
+struct MockState {
+    value: String,
+}
+
+#[derive(Debug, Default, WithId, TypeName, ManagedState)]
+struct MockService {
+    id: String,
+    #[managed_state(provider = LocalState)]
+    state: MockState,
+}
+
+#[async_trait]
+impl ServiceObject for MockService {
+    async fn before_load(&mut self, _: Arc<AppData>) -> Result<(), ServiceObjectLifeCycleError> {
+        if &self.id == "1" {
+            panic!("Panico");
+        } else if &self.id == "2" {
+            Err(ServiceObjectLifeCycleError::Unknown)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<OkMessage> for MockService {
+    type Returns = MockResponse;
+    async fn handle(
+        &mut self,
+        _: OkMessage,
+        _: Arc<AppData>,
+    ) -> Result<Self::Returns, HandlerError> {
+        let resp = MockResponse {};
+        Ok(resp)
+    }
+}
+
+fn build_registry() -> Registry {
+    let mut registry = Registry::new();
+    registry.add_type::<MockService>();
+    registry.add_handler::<MockService, LifecycleMessage>();
+    registry
+}
+
+#[tokio::test]
+async fn service_is_not_allocated_on_lifecycle_handlers_panic() {
+    let members_storage = LocalStorage::default();
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        1,
+        || async move {
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage)
+                .build()
+                .unwrap();
+            assert!(!is_allocated(&object_placement_provider, "MockService", "1").await);
+
+            let message = OkMessage {};
+            let resp: Result<MockResponse, _> = client.send("MockService", "1", &message).await;
+            assert_eq!(
+                resp,
+                Err(ClientError::ResponseError(ResponseError::Allocate))
+            );
+            assert!(!is_allocated(&object_placement_provider, "MockService", "1").await);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn service_is_not_allocated_on_lifecycle_handlers_error() {
+    let members_storage = LocalStorage::default();
+    let object_placement_provider = LocalObjectPlacementProvider::default();
+
+    run_integration_test(
+        5,
+        &build_registry,
+        members_storage.clone(),
+        object_placement_provider.clone(),
+        1,
+        || async move {
+            let mut client = ClientBuilder::new()
+                .members_storage(members_storage)
+                .build()
+                .unwrap();
+            assert!(!is_allocated(&object_placement_provider, "MockService", "2").await);
+
+            let message = OkMessage {};
+            let resp: Result<MockResponse, _> = client.send("MockService", "1", &message).await;
+            assert_eq!(
+                resp,
+                Err(ClientError::ResponseError(ResponseError::Allocate))
+            );
+            assert!(!is_allocated(&object_placement_provider, "MockService", "2").await);
+        },
+    )
+    .await;
+}

--- a/rio-rs/tests/state.rs
+++ b/rio-rs/tests/state.rs
@@ -1,0 +1,112 @@
+use rio_rs::errors::LoadStateError;
+use rio_rs::state::{StateLoader, StateSaver};
+use serde::{Deserialize, Serialize};
+
+mod db_utils;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct State {
+    id: usize,
+    name: String,
+    labels: Vec<String>,
+}
+
+async fn state_save_sanity_check<S: StateSaver + StateLoader<State>>(storage: S) {
+    StateSaver::prepare(&storage).await;
+
+    let state = State {
+        id: 123,
+        name: "Something".to_string(),
+        labels: vec!["lbl1".to_string(), "lbl2".to_string()],
+    };
+    storage
+        .save("ObjectWithState", "123", "state_attr", &state)
+        .await
+        .unwrap();
+    let loaded_state: State = storage
+        .load("ObjectWithState", "123", "state_attr")
+        .await
+        .unwrap();
+    assert_eq!(state, loaded_state);
+}
+
+async fn state_load_not_found<S: StateSaver + StateLoader<State>>(storage: S) {
+    StateSaver::prepare(&storage).await;
+
+    let loaded_state: Result<State, _> = storage.load("ObjectWithState", "999", "state_attr").await;
+    assert_eq!(loaded_state, Err(LoadStateError::ObjectNotFound));
+}
+
+mod redis {
+    use rio_rs::state::redis::RedisState;
+
+    #[tokio::test]
+    async fn state_save_sanity_check() {
+        let prefix = chrono::Local::now().timestamp_micros().to_string();
+        let storage =
+            RedisState::from_connect_string("redis://localhost:16379", Some(prefix)).await;
+        super::state_save_sanity_check(storage).await;
+    }
+
+    #[tokio::test]
+    async fn state_load_not_found() {
+        let prefix = chrono::Local::now().timestamp_micros().to_string();
+        let storage =
+            RedisState::from_connect_string("redis://localhost:16379", Some(prefix)).await;
+        super::state_load_not_found(storage).await;
+    }
+}
+
+mod sqlite {
+    use super::db_utils::sqlite::pool;
+    use rio_rs::state::sql::SqlState;
+
+    #[tokio::test]
+    async fn state_save_sanity_check() {
+        let pool = pool().await;
+        let storage = SqlState::new(pool);
+        super::state_save_sanity_check(storage).await;
+    }
+
+    #[tokio::test]
+    async fn state_load_not_found() {
+        let pool = pool().await;
+        let storage = SqlState::new(pool);
+        super::state_load_not_found(storage).await;
+    }
+}
+
+mod pgsql {
+    use super::db_utils::pgsql::pool;
+    use rio_rs::state::sql::SqlState;
+
+    #[tokio::test]
+    async fn state_save_sanity_check() {
+        let pool = pool("state_save_sanity_check").await;
+        let storage = SqlState::new(pool);
+        super::state_save_sanity_check(storage).await;
+    }
+
+    #[tokio::test]
+    async fn state_load_not_found() {
+        let pool = pool("state_load_not_found").await;
+        let storage = SqlState::new(pool);
+        super::state_load_not_found(storage).await;
+    }
+}
+
+mod local {
+    use rio_rs::state::local::LocalState;
+
+    #[tokio::test]
+    async fn state_save_sanity_check() {
+        let storage = LocalState::default();
+        super::state_save_sanity_check(storage).await;
+    }
+
+    #[tokio::test]
+    async fn state_load_not_found() {
+        let storage = LocalState::default();
+        super::state_load_not_found(storage).await;
+    }
+}


### PR DESCRIPTION
Other changes:

- BREAKING - Replace `Option<T>` with `T: Default` when working with managed state
- BREAKING - Support to ephemeral ports
- Feat: Improve error handling (reducing panics)
- Refactor: Replace println with logging
- Test: Add integration tests to cover most backends when available (Redis, Local, Sqlite, PgSQL)
- Test: Add services for integration test - Uses nextest script for local, and github services for CI
- Test: Add test utilities to run the server for integration
